### PR TITLE
Allow customer ID to be overridden by passed params

### DIFF
--- a/lib/braintree_blue/api.rb
+++ b/lib/braintree_blue/api.rb
@@ -91,7 +91,8 @@ module Killbill #:nodoc:
       end
 
       def add_payment_method(kb_account_id, kb_payment_method_id, payment_method_props, set_default, properties, context)
-       braintree_customer_id = BraintreeBluePaymentMethod.braintree_customer_id_from_kb_account_id(kb_account_id, context.tenant_id)
+        braintree_customer_id = find_value_from_properties(payment_method_props.properties, :customer) ||
+          BraintreeBluePaymentMethod.braintree_customer_id_from_kb_account_id(kb_account_id, context.tenant_id)
 
         options = {
             :customer => braintree_customer_id,

--- a/lib/braintree_blue/models/payment_method.rb
+++ b/lib/braintree_blue/models/payment_method.rb
@@ -5,7 +5,7 @@ module Killbill #:nodoc:
       self.table_name = 'braintree_blue_payment_methods'
 
       def self.from_response(kb_account_id, kb_payment_method_id, kb_tenant_id, cc_or_token, response, options, extra_params = {}, model = ::Killbill::BraintreeBlue::BraintreeBluePaymentMethod)
-        braintree_customer_id = self.braintree_customer_id_from_kb_account_id(kb_account_id, kb_tenant_id)
+        braintree_customer_id = options[:customer] || self.braintree_customer_id_from_kb_account_id(kb_account_id, kb_tenant_id)
 
         unless braintree_customer_id.blank?
           card_response     = response.responses.first.params


### PR DESCRIPTION
This PR allows for a `customer` to be specified in the plugin properties when creating a new payment method, in case the customer already exists in braintree and you don't want another to be created. Without being able to specify the customer, payment methods cannot be created in KillBill when using the `skip_gw` plugin option.

I'm not sure if I'm doing this correctly, so feel free to give me some pointers if I'm not.
