### PR TITLE
Allowing for overriding the token when creating payment methods with skip_gw option

### DIFF
--- a/lib/braintree_blue/api.rb
+++ b/lib/braintree_blue/api.rb
@@ -98,8 +98,9 @@ module Killbill #:nodoc:
           BraintreeBluePaymentMethod.braintree_customer_id_from_kb_account_id(kb_account_id, context.tenant_id)
 
         options = {
-            :customer => braintree_customer_id,
-            :company => kb_account_id
+          :token => find_value_from_properties(payment_method_props.properties, :token),
+          :customer => braintree_customer_id,
+          :company => kb_account_id
         }
         properties = merge_properties(properties, options)
         super(kb_account_id, kb_payment_method_id, payment_method_props, set_default, properties, context)

--- a/lib/braintree_blue/models/payment_method.rb
+++ b/lib/braintree_blue/models/payment_method.rb
@@ -13,7 +13,7 @@ module Killbill #:nodoc:
         # Unfortunately, the ActiveMerchant Braintree implementation will drop that information when adding a card to an existing customer
         customer_response = primary_response.params['braintree_customer'] || {}
 
-        token = primary_response.params['credit_card_token']
+        token = options[:token] || primary_response.params['credit_card_token']
         card_response = (customer_response['credit_cards'] || []).first || {}
         cc_exp_dates = (card_response['expiration_date'] || '').split('/')
 


### PR DESCRIPTION
Relates to https://github.com/killbill/killbill-braintree-blue-plugin/issues/3.
